### PR TITLE
Logging Updates & Pinned Branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-https://github.com/user-attachments/assets/f711bcb7-925a-4346-88b6-a567d625c5d6
-
-
 # git-switch
 
 A fast, interactive terminal UI for switching between git branches. Built with [tcell](https://github.com/gdamore/tcell) for a smooth, cross-platform experience.
@@ -10,7 +7,7 @@ Switching branches with `git checkout` or `git switch` can be slow, especially i
 ## Features
 
 - **Fuzzy search**: Instantly filter branches as you type.
-- **Focus Branches**: A configurable list of branches that will always show at the top of the list.
+- **Pinned Branches**: A configurable list of branches that will always show at the top of the list.
 - **Keyboard navigation**: Use arrow keys to move, Enter to switch, and Esc/Ctrl+C to quit.
 - **Direct checkout**: Pass a branch name as an argument to switch without the UI.
 
@@ -20,7 +17,15 @@ Switching branches with `git checkout` or `git switch` can be slow, especially i
 go install github.com/nathan-fiscaletti/git-switch@latest
 ```
 
-> I highly recommend that you alias the `git-switch` command to `sw` in your shell for eas-of-use.
+> ℹ️ I highly recommend that you alias the `git-switch` command to `sw` in your shell for eas-of-use. The rest of this documentation will make the assumption that you have. If not, use `git-switch` instead of `sw` for each command.
+> 
+> ```sh
+> # Windows Powershell
+> "`nset-alias sw git-switch" | out-file -append -encoding utf8 $profile; . > $profile
+> 
+> # Bash (use .zshrc for zsh, etc.)
+> echo "alias sw='git-switch'" >> ~/.bashrc && source ~/.bashrc
+> ```
 
 ## Usage
 
@@ -29,7 +34,7 @@ go install github.com/nathan-fiscaletti/git-switch@latest
 Just run:
 
 ```sh
-git-switch
+sw
 ```
 
 - Start typing to filter branches.
@@ -42,21 +47,21 @@ git-switch
 To checkout a branch directly (no UI):
 
 ```sh
-git-switch <branch-name>
+sw <branch-name>
 ```
 
-> Unless prefixed with `-x`, any arguments passed to `git-switch` will be forwarded to `git checkout`.
+> Unless prefixed with `-x`, any arguments passed to `sw` will be forwarded to `git checkout`.
 
 If the branch exists, you’ll be switched immediately.
 
-### Focus Branches
+### Pinned Branches
 
-A focused branch always shows at the top of the list of branches in the switcher.
+A pinned branch always shows at the top of the list of branches in the switcher.
 
 ```sh
 # While a branch is checked out
-git-switch -x focus
-git-switch -x unfocus
+sw -x pin
+sw -x unpin
 ```
 
 ## License

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -8,8 +8,9 @@ import (
 )
 
 func ListRemotes() ([]string, error) {
-	out, err := execute("remote")
+	out, err := executeHide("remote")
 	if err != nil {
+		print(out)
 		return nil, err
 	}
 
@@ -22,8 +23,9 @@ func AllBranches() ([]string, error) {
 		return nil, err
 	}
 
-	out, err := execute("branch -a --format=%%(refname:short)")
+	out, err := executeHide("branch -a --format=%%(refname:short)")
 	if err != nil {
+		print(out)
 		return nil, err
 	}
 
@@ -55,8 +57,9 @@ func ExecuteCheckout(cmd string, args ...any) error {
 }
 
 func GetCurrentBranch() (string, error) {
-	res, err := execute("branch %v", "--show-current")
+	res, err := executeHide("branch %v", "--show-current")
 	if err != nil {
+		print(res)
 		return res, err
 	}
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -19,15 +19,16 @@ func ValidateGitInstallation() error {
 }
 
 func IsGitRepository() (bool, error) {
-	res, err := execute("rev-parse --is-inside-work-tree")
+	res, err := executeHide("rev-parse --is-inside-work-tree")
 	if err != nil {
+		print(res)
 		return false, err
 	}
 
 	return strings.TrimSpace(res) == "true", nil
 }
 
-func execute(format string, args ...any) (string, error) {
+func executeHide(format string, args ...any) (string, error) {
 	slog.Debug("executing git command", slog.String("command", fmt.Sprintf(format, args...)))
 
 	cmdFormatted := fmt.Sprintf(format, args...)

--- a/main.go
+++ b/main.go
@@ -31,27 +31,31 @@ func main() {
 		switch cmd {
 		case "-x":
 			switch args[0] {
-			case "focus":
+			case "focus": // Maintain 'focus' for backwards compatibility.
+				fallthrough
+			case "pin":
 				currentBranch, err := git.GetCurrentBranch()
 				if err != nil {
 					fmt.Printf("error: %v\n", err)
 					os.Exit(1)
 				}
 
-				_, err = storage.Focus(currentBranch)
+				_, err = storage.Pin(currentBranch)
 				if err != nil {
 					fmt.Printf("error: %v\n", err)
 					os.Exit(1)
 				}
 				os.Exit(0)
-			case "unfocus":
+			case "unfocus": // Maintain 'unfocus' for backwards compatibility
+				fallthrough
+			case "unpin":
 				currentBranch, err := git.GetCurrentBranch()
 				if err != nil {
 					fmt.Printf("error: %v\n", err)
 					os.Exit(1)
 				}
 
-				_, err = storage.Unfocus(currentBranch)
+				_, err = storage.Unpin(currentBranch)
 				if err != nil {
 					fmt.Printf("error: %v\n", err)
 					os.Exit(1)
@@ -89,19 +93,20 @@ func main() {
 		os.Exit(1)
 	}
 
-	focusBranches := []string{}
+	pinnedBranches := []string{}
 
 	if repo, repoFound := lo.Find(cfg.Repositories, func(r storage.RepositoryConfig) bool {
 		return r.Path == repositoryPath
 	}); repoFound {
-		focusBranches = repo.FocusBranches
+		pinnedBranches = repo.PinnedBranches
 	}
 
 	branchSelector, err := pkg.NewBranchSelector(pkg.BranchSelectorArguments{
-		Branches:      branches,
-		WindowSize:    10,
-		SearchLabel:   "search branch",
-		FocusBranches: focusBranches,
+		Branches:           branches,
+		WindowSize:         10,
+		SearchLabel:        "search branch",
+		PinnedBranches:     pinnedBranches,
+		PinnedBranchPrefix: cfg.PinnedBranchPrefix,
 	})
 	if err != nil {
 		panic(err)

--- a/pkg/branch-selector.go
+++ b/pkg/branch-selector.go
@@ -9,9 +9,11 @@ import (
 type BranchSelectorArguments struct {
 	// The list of branches to pick from.
 	Branches []string
-	// The focus branches to display these will always be displayed at the
+	// The pinned branches to display these will always be displayed at the
 	// top of the list when able.
-	FocusBranches []string
+	PinnedBranches []string
+	// PinnedBranchPrefix is the prefix to use before pinned branches.
+	PinnedBranchPrefix string
 	// The maximum number of branches to show at any given time.
 	WindowSize int
 	// The label to show in front of the search input.
@@ -31,10 +33,11 @@ type BranchSelector struct {
 func (b *BranchSelector) PickBranch() (string, error) {
 	renderer, err := internal.NewRenderer(
 		internal.RendererConfig{
-			Branches:      b.cfg.Branches,
-			FocusBranches: b.cfg.FocusBranches,
-			WindowSize:    b.cfg.WindowSize,
-			SearchLabel:   b.cfg.SearchLabel,
+			Branches:           b.cfg.Branches,
+			PinnedBranches:     b.cfg.PinnedBranches,
+			WindowSize:         b.cfg.WindowSize,
+			SearchLabel:        b.cfg.SearchLabel,
+			PinnedBranchPrefix: b.cfg.PinnedBranchPrefix,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
- Changed `focus branches` to `pinned branches`
- Updated focus/unfocus commands to be pin/unpin (backwards compatible)
- Added support for customizable pinned branch prefix. Defaults to "★"
- Fixed issues with git command errors always being reported as "exit code 128"