### PR TITLE
Pinning Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ sw -b <branch-name>
 # etc...
 ```
 
+## Internal Commands
+
+> [!TIP]\
+> Passing `-x` to `git-switch` will tell it you are executing an internal command.
+
 ### Pinned Branches
 
 A pinned branch always shows at the top of the list of branches in the switcher.
@@ -68,7 +73,18 @@ sw -x pin
 sw -x unpin
 ```
 
-> Passing `-x` to `git-switch` will tell it you are executing an internal command.
+By default, the currently checked out branch will be pinned/un-pinned. If you wish to pin/un-pin another branch, you can pass it in as an optional parameter.
+
+```sh
+sw -x pin <branch>
+sw -x unpin <branch>
+```
+
+You can clear all pinned branches by running
+
+```sh
+sw -x unpin all
+```
 
 ### Popping branches
 

--- a/internal/storage/pinning.go
+++ b/internal/storage/pinning.go
@@ -77,3 +77,23 @@ func Unpin(branch string) (*Config, error) {
 
 	return cfg, write(cfg)
 }
+
+func ClearPins() error {
+	cfg, err := GetConfig()
+	if err != nil {
+		return err
+	}
+
+	repositoryPath, err := git.GetRepositoryPath()
+	if err != nil {
+		return err
+	}
+
+	if _, idx, found := lo.FindIndexOf(cfg.Repositories, func(r RepositoryConfig) bool {
+		return r.Path == repositoryPath
+	}); found {
+		cfg.Repositories[idx].PinnedBranches = []string{}
+	}
+
+	return write(cfg)
+}

--- a/main.go
+++ b/main.go
@@ -37,35 +37,58 @@ func main() {
 			}
 
 			switch args[0] {
-			case "focus": // Maintain 'focus' for backwards compatibility.
-				fallthrough
 			case "pin":
-				currentBranch, err := git.GetCurrentBranch()
-				if err != nil {
-					fmt.Printf("error: %v\n", err)
-					os.Exit(1)
+				args = args[1:]
+
+				var branch string
+				if len(args) > 0 {
+					branch = args[0]
+				} else {
+					branch, err = git.GetCurrentBranch()
+					if err != nil {
+						fmt.Printf("error: %v\n", err)
+						os.Exit(1)
+					}
 				}
 
-				_, err = storage.Pin(currentBranch)
+				_, err = storage.Pin(branch)
 				if err != nil {
 					fmt.Printf("error: %v\n", err)
 					os.Exit(1)
 				}
 				os.Exit(0)
-			case "unfocus": // Maintain 'unfocus' for backwards compatibility
-				fallthrough
 			case "unpin":
-				currentBranch, err := git.GetCurrentBranch()
+				args = args[1:]
+
+				var branch string
+				if len(args) > 0 {
+					branch = args[0]
+				} else {
+					branch, err = git.GetCurrentBranch()
+					if err != nil {
+						fmt.Printf("error: %v\n", err)
+						os.Exit(1)
+					}
+				}
+
+				if branch == "all" || branch == "*" {
+					err = storage.ClearPins()
+					if err != nil {
+						fmt.Printf("error: %v\n", err)
+						os.Exit(1)
+					}
+
+					println("Unpinned all pinned branches")
+					os.Exit(0)
+				}
+
+				_, err = storage.Unpin(branch)
 				if err != nil {
 					fmt.Printf("error: %v\n", err)
 					os.Exit(1)
 				}
 
-				_, err = storage.Unpin(currentBranch)
-				if err != nil {
-					fmt.Printf("error: %v\n", err)
-					os.Exit(1)
-				}
+				fmt.Printf("Unpinned %v\n", branch)
 				os.Exit(0)
 			case "pipe":
 				pipeOutput = true


### PR DESCRIPTION
- Removed deprecated "focus" and "unfocus" internal commands
- Added "unpin all" internal command.
- Added "branch" argument to "pin" and "unpin" internal commands.